### PR TITLE
What: Ensure all tiles within a tile set are of the same shape.

### DIFF
--- a/src/main/java/noelyap/setterforcatan/component/SpecificationImpl.java
+++ b/src/main/java/noelyap/setterforcatan/component/SpecificationImpl.java
@@ -99,7 +99,7 @@ public class SpecificationImpl {
     }
 
     public Builder withFisheries(final Array<Coordinate> fisheryCoordinates) {
-      final Tile fisheryTile = Tile.newBuilder().setType(Tile.Type.FISHERY).build();
+      final Tile fisheryTile = noelyap.setterforcatan.component.Tiles.FISHERY;
       final Stream<Chit> fisheryChits =
           Stream.of(CHIT_4, CHIT_10, CHIT_5, CHIT_9, CHIT_6, CHIT_8, CHIT_5, CHIT_9);
 
@@ -298,6 +298,7 @@ public class SpecificationImpl {
         checkForEmptyFeatureMaps("tiles", tiles)
             .union(checkForEmptyFeatureMaps("coordinates", coordinates))
             .union(checkForEmptyFeatureMaps("chits", chits))
+            .union(checkTileShapes(tiles))
             .union(checkForDuplicateCoordinates(coordinates))
             .union(
                 checkForUnreferencedTilesErrors(
@@ -328,6 +329,27 @@ public class SpecificationImpl {
     return featuresMap.isEmpty()
         ? HashSet.of(String.format("%s map is empty.", StringUtils.capitalize(feature)))
         : HashSet.empty();
+  }
+
+  @VisibleForTesting
+  static Set<String> checkTileShapes(final Map<String, Array<Tile>> tileSets) {
+    return tileSets
+        .flatMap(t2 -> {
+              final var tileName = t2._1;
+              final var tiles = t2._2;
+
+              final Set<Tile.Shape> shapes = tiles.map(Tile::getShape).toSet();
+
+              return (shapes.size() < 2
+                  ? Option.none()
+                  : Option.of(
+                      String.format(
+                          "\"%s\" tiles contain mixed shapes: %s",
+                          tileName,
+                          String.join(
+                              ", ", shapes.map(Tile.Shape::toString).toJavaArray(String[]::new)))));
+            })
+        .toSet();
   }
 
   @VisibleForTesting

--- a/src/main/java/noelyap/setterforcatan/component/Tiles.java
+++ b/src/main/java/noelyap/setterforcatan/component/Tiles.java
@@ -7,6 +7,8 @@ import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Vertex.Positi
 import io.vavr.collection.Array;
 import noelyap.setterforcatan.protogen.CoordinateOuterClass.Vertex;
 import noelyap.setterforcatan.protogen.TileOuterClass.Tile;
+import noelyap.setterforcatan.protogen.TileOuterClass.Tile.Shape;
+import noelyap.setterforcatan.protogen.TileOuterClass.Tile.Type;
 
 public class Tiles {
   // TODO: Move into proto definitions.
@@ -14,46 +16,45 @@ public class Tiles {
   public static final String FISHERY_NAME = "«FISHERY»";
   public static final String LAKE_NAME = "«LAKE»";
 
-  public static final Tile GENERIC_HARBOR = Tiles.ofType(Tile.Type.GENERIC_HARBOR);
-  public static final Tile BRICK_HARBOR = Tiles.ofType(Tile.Type.BRICK_HARBOR);
-  public static final Tile GRAIN_HARBOR = Tiles.ofType(Tile.Type.GRAIN_HARBOR);
-  public static final Tile LUMBER_HARBOR = Tiles.ofType(Tile.Type.LUMBER_HARBOR);
-  public static final Tile ORE_HARBOR = Tiles.ofType(Tile.Type.ORE_HARBOR);
-  public static final Tile WOOL_HARBOR = Tiles.ofType(Tile.Type.WOOL_HARBOR);
+  public static final Tile GENERIC_HARBOR = Tiles.ofType(Type.GENERIC_HARBOR, Shape.TRIANGLE);
+  public static final Tile BRICK_HARBOR = Tiles.ofType(Type.BRICK_HARBOR, Shape.TRIANGLE);
+  public static final Tile GRAIN_HARBOR = Tiles.ofType(Type.GRAIN_HARBOR, Shape.TRIANGLE);
+  public static final Tile LUMBER_HARBOR = Tiles.ofType(Type.LUMBER_HARBOR, Shape.TRIANGLE);
+  public static final Tile ORE_HARBOR = Tiles.ofType(Type.ORE_HARBOR, Shape.TRIANGLE);
+  public static final Tile WOOL_HARBOR = Tiles.ofType(Type.WOOL_HARBOR, Shape.TRIANGLE);
 
-  public static final Tile DESERT = Tiles.ofType(Tile.Type.DESERT);
-  public static final Tile FIELD = Tiles.ofType(Tile.Type.FIELD);
-  public static final Tile FOREST = Tiles.ofType(Tile.Type.FOREST);
-  public static final Tile HILL = Tiles.ofType(Tile.Type.HILL);
-  public static final Tile MOUNTAIN = Tiles.ofType(Tile.Type.MOUNTAIN);
-  public static final Tile PASTURE = Tiles.ofType(Tile.Type.PASTURE);
+  public static final Tile DESERT = Tiles.ofType(Type.DESERT, Shape.HEXAGON);
+  public static final Tile FIELD = Tiles.ofType(Type.FIELD, Shape.HEXAGON);
+  public static final Tile FOREST = Tiles.ofType(Type.FOREST, Shape.HEXAGON);
+  public static final Tile HILL = Tiles.ofType(Type.HILL, Shape.HEXAGON);
+  public static final Tile MOUNTAIN = Tiles.ofType(Type.MOUNTAIN, Shape.HEXAGON);
+  public static final Tile PASTURE = Tiles.ofType(Type.PASTURE, Shape.HEXAGON);
 
-  public static final Tile SEA = Tiles.ofType(Tile.Type.SEA);
-  public static final Tile LAKE = Tiles.ofType(Tile.Type.LAKE);
-  public static final Tile FISHERY = Tiles.ofType(Tile.Type.FISHERY);
-  public static final Tile RIVER = Tiles.ofType(Tile.Type.RIVER);
+  public static final Tile SEA = Tiles.ofType(Type.SEA, Shape.HEXAGON);
+  public static final Tile LAKE = Tiles.ofType(Type.LAKE, Shape.HEXAGON);
+  public static final Tile FISHERY = Tiles.ofType(Type.FISHERY, Shape.CHEVRON);
+  public static final Tile RIVER = Tiles.ofType(Type.RIVER, Shape.POLYMORPHIC);
 
-  public static final Tile GOLD_FIELD = Tiles.ofType(Tile.Type.GOLD_FIELD);
-  public static final Tile SWAMP = Tiles.ofType(Tile.Type.SWAMP);
+  public static final Tile GOLD_FIELD = Tiles.ofType(Type.GOLD_FIELD, Shape.HEXAGON);
+  public static final Tile SWAMP = Tiles.ofType(Type.SWAMP, Shape.HEXAGON);
   public static final Tile OASIS =
-      Tiles.withSpecialVertices(Tile.Type.OASIS, TOP_RIGHT, BOTTOM, TOP_LEFT);
-  public static final Tile CASTLE = Tiles.ofType(Tile.Type.CASTLE);
-  public static final Tile GLASSWORKS = Tiles.ofType(Tile.Type.GLASSWORKS);
-  public static final Tile QUARRY = Tiles.ofType(Tile.Type.QUARRY);
+      Tiles.withSpecialVertices(Type.OASIS, TOP_RIGHT, BOTTOM, TOP_LEFT);
+  public static final Tile CASTLE = Tiles.ofType(Type.CASTLE, Shape.HEXAGON);
+  public static final Tile GLASSWORKS = Tiles.ofType(Type.GLASSWORKS, Shape.HEXAGON);
+  public static final Tile QUARRY = Tiles.ofType(Type.QUARRY, Shape.HEXAGON);
 
-  public static final Tile DEVELOPMENT_CARD = Tiles.ofType(Tile.Type.DEVELOPMENT_CARD);
-  public static final Tile VICTORY_POINT = Tiles.ofType(Tile.Type.VICTORY_POINT);
-  public static final Tile CHIT = Tiles.ofType(Tile.Type.CHIT);
+  public static final Tile DEVELOPMENT_CARD = Tiles.ofType(Type.DEVELOPMENT_CARD, Shape.RECTANGLE);
+  public static final Tile VICTORY_POINT = Tiles.ofType(Type.VICTORY_POINT, Shape.POLYMORPHIC);
+  public static final Tile CHIT = Tiles.ofType(Type.CHIT, Shape.POINT);
 
   public static final Array<Tile> TWO_FOR_ONE_HARBORS =
       Array.of(GRAIN_HARBOR, LUMBER_HARBOR, WOOL_HARBOR, BRICK_HARBOR, ORE_HARBOR);
 
-  private static Tile ofType(final Tile.Type type) {
-    return Tile.newBuilder().setType(type).build();
+  private static Tile ofType(final Type type, final Tile.Shape shape) {
+    return Tile.newBuilder().setType(type).setShape(shape).build();
   }
 
-  private static Tile withSpecialVertices(
-      final Tile.Type type, Vertex.Position... specialVertices) {
+  private static Tile withSpecialVertices(final Type type, Vertex.Position... specialVertices) {
     return Tile.newBuilder().setType(type).addAllSpecialVertices(Array.of(specialVertices)).build();
   }
 }

--- a/src/test/java/noelyap/setterforcatan/component/SpecificationImplTest.java
+++ b/src/test/java/noelyap/setterforcatan/component/SpecificationImplTest.java
@@ -26,12 +26,17 @@ import static noelyap.setterforcatan.component.Tiles.PASTURE;
 import static noelyap.setterforcatan.component.Tiles.QUARRY;
 import static noelyap.setterforcatan.component.Tiles.SEA;
 import static noelyap.setterforcatan.component.Tiles.SWAMP;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.BOTTOM_LEFT;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.BOTTOM_RIGHT;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.LEFT;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.RIGHT;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.TOP_LEFT;
+import static noelyap.setterforcatan.protogen.CoordinateOuterClass.Edge.Position.TOP_RIGHT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import io.vavr.Tuple3;
 import io.vavr.collection.Array;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
@@ -43,7 +48,6 @@ import noelyap.setterforcatan.matcher.TileIs;
 import noelyap.setterforcatan.protogen.ChitOuterClass.Chit;
 import noelyap.setterforcatan.protogen.ConfigurationOuterClass.Configuration;
 import noelyap.setterforcatan.protogen.CoordinateOuterClass.Coordinate;
-import noelyap.setterforcatan.protogen.CoordinateOuterClass.Vertex;
 import noelyap.setterforcatan.protogen.TileOuterClass.Tile;
 import noelyap.setterforcatan.util.MersenneTwister;
 import noelyap.setterforcatan.util.TileMappingUtils;
@@ -96,16 +100,16 @@ public class SpecificationImplTest {
             TileMappingUtils.newSelfReferringEntry(DESERT_OR_LAKE_NAME));
 
     final Array<Coordinate> fisheriesCoordinates =
-        newCoordinates(
-            Tuple.of(6, 6, Vertex.Position.TOP),
-            Tuple.of(7, 7, Vertex.Position.TOP_RIGHT),
-            Tuple.of(8, 8, Vertex.Position.BOTTOM_RIGHT),
-            Tuple.of(9, 9, Vertex.Position.BOTTOM),
-            Tuple.of(10, 10, Vertex.Position.BOTTOM_LEFT),
-            Tuple.of(11, 11, Vertex.Position.TOP_LEFT),
-            Tuple.of(12, 12, Vertex.Position.TOP),
-            Tuple.of(13, 13, Vertex.Position.BOTTOM_RIGHT),
-            Tuple.of(14, 14, Vertex.Position.BOTTOM_LEFT));
+        Array.of(
+            Coordinates.onEdges(6, 6, TOP_LEFT, TOP_RIGHT),
+            Coordinates.onEdges(7, 7, TOP_RIGHT, RIGHT),
+            Coordinates.onEdges(8, 8, RIGHT, BOTTOM_RIGHT),
+            Coordinates.onEdges(9, 9, BOTTOM_RIGHT, BOTTOM_LEFT),
+            Coordinates.onEdges(10, 10, BOTTOM_LEFT, LEFT),
+            Coordinates.onEdges(11, 11, LEFT, TOP_LEFT),
+            Coordinates.onEdges(12, 12, TOP_LEFT, TOP_RIGHT),
+            Coordinates.onEdges(13, 13, RIGHT, BOTTOM_RIGHT),
+            Coordinates.onEdges(14, 14, BOTTOM_LEFT, LEFT));
 
     final Array<Configuration> actual =
         SpecificationImpl.newBuilder(tiles, coordinates, chits, coordinatesTilesMap, chitsTilesMap)
@@ -334,6 +338,17 @@ public class SpecificationImplTest {
 
     assertThat(actual).isNotEmpty();
     assertThat(actual.get()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("Should validate tile shapes.")
+  public void shouldValidateTileShapes() {
+    final Map<String, Array<Tile>> waterTiles = HashMap.of("water", Array.of(LAKE, FISHERY, SEA));
+
+    final Set<String> actual = SpecificationImpl.checkTileShapes(waterTiles);
+
+    assertThat(actual)
+        .containsExactlyInAnyOrder("\"water\" tiles contain mixed shapes: HEXAGON, CHEVRON");
   }
 
   @Test
@@ -743,14 +758,5 @@ public class SpecificationImplTest {
     final Option<Array<Configuration>> actual = specification.toConfiguration();
 
     assertThat(actual).isEmpty();
-  }
-
-  private Array<Coordinate> newCoordinates(
-      final Tuple3<Integer, Integer, Vertex.Position>... tuple3s) {
-    return Array.of(tuple3s).map(t3 -> newCoordinate(t3._1, t3._2, t3._3));
-  }
-
-  private Coordinate newCoordinate(final int x, final int y, final Vertex.Position p) {
-    return Coordinate.newBuilder().setX(x).setY(y).addVertexPositions(p).build();
   }
 }


### PR DESCRIPTION
Why: To catch configuration errors earlier.